### PR TITLE
fix: update java-version from 17 to 21 in GitHub Actions workflows

### DIFF
--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
           check-latest: true
 
       - name: Setup Project

--- a/.github/workflows/android_qa_apk.yml
+++ b/.github/workflows/android_qa_apk.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
           check-latest: true
 
       - name: Setup Project

--- a/.github/workflows/android_quality.yml
+++ b/.github/workflows/android_quality.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
           check-latest: true
 
       - name: Setup Project


### PR DESCRIPTION
fix: update Java version to 21 in GitHub Actions workflows

CI failed with "invalid source release: 21" because setup-java used Java 17 while the project targets JVM 21.